### PR TITLE
Handle unbraced command arguments

### DIFF
--- a/src/core/latex2typst/context.rs
+++ b/src/core/latex2typst/context.rs
@@ -897,14 +897,19 @@ impl LatexConverter {
     pub fn get_required_arg(&self, cmd: &CmdItem, index: usize) -> Option<String> {
         let mut required_count = 0;
         for child in cmd.syntax().children() {
-            if child.kind() == SyntaxKind::ClauseArgument {
-                let is_curly = child.children().any(|c| c.kind() == SyntaxKind::ItemCurly);
-                if is_curly {
-                    if required_count == index {
-                        return Some(extract_arg_content(&child));
-                    }
-                    required_count += 1;
+            if child.kind() == SyntaxKind::ClauseArgument
+                && !child
+                    .children()
+                    .any(|c| c.kind() == SyntaxKind::ItemBracket)
+                && !matches!(
+                    child.first_token().map(|t| t.kind()),
+                    Some(SyntaxKind::TokenLBracket)
+                )
+            {
+                if required_count == index {
+                    return Some(extract_arg_content(&child));
                 }
+                required_count += 1;
             }
         }
         None
@@ -914,14 +919,19 @@ impl LatexConverter {
     pub fn get_required_arg_with_braces(&self, cmd: &CmdItem, index: usize) -> Option<String> {
         let mut required_count = 0;
         for child in cmd.syntax().children() {
-            if child.kind() == SyntaxKind::ClauseArgument {
-                let is_curly = child.children().any(|c| c.kind() == SyntaxKind::ItemCurly);
-                if is_curly {
-                    if required_count == index {
-                        return Some(extract_arg_content_with_braces(&child));
-                    }
-                    required_count += 1;
+            if child.kind() == SyntaxKind::ClauseArgument
+                && !child
+                    .children()
+                    .any(|c| c.kind() == SyntaxKind::ItemBracket)
+                && !matches!(
+                    child.first_token().map(|t| t.kind()),
+                    Some(SyntaxKind::TokenLBracket)
+                )
+            {
+                if required_count == index {
+                    return Some(extract_arg_content_with_braces(&child));
                 }
+                required_count += 1;
             }
         }
         None
@@ -950,29 +960,29 @@ impl LatexConverter {
     pub fn convert_required_arg(&mut self, cmd: &CmdItem, index: usize) -> Option<String> {
         let mut required_count = 0;
         for child in cmd.syntax().children() {
-            if child.kind() == SyntaxKind::ClauseArgument {
-                let is_curly = child.children().any(|c| c.kind() == SyntaxKind::ItemCurly);
-                if is_curly {
-                    if required_count == index {
-                        let mut output = String::new();
-                        for arg_child in child.children() {
-                            if arg_child.kind() == SyntaxKind::ItemCurly {
-                                for content in arg_child.children_with_tokens() {
-                                    match content.kind() {
-                                        SyntaxKind::TokenLBrace | SyntaxKind::TokenRBrace => {
-                                            continue
-                                        }
-                                        _ => {
-                                            self.visit_element(content, &mut output);
-                                        }
-                                    }
-                                }
-                            }
+            if child.kind() == SyntaxKind::ClauseArgument
+                && !child
+                    .children()
+                    .any(|c| c.kind() == SyntaxKind::ItemBracket)
+                && !matches!(
+                    child.first_token().map(|t| t.kind()),
+                    Some(SyntaxKind::TokenLBracket)
+                )
+            {
+                if required_count == index {
+                    let mut output = String::new();
+                    for content in child.children_with_tokens() {
+                        match content.kind() {
+                            SyntaxKind::TokenLBrace
+                            | SyntaxKind::TokenRBrace
+                            | SyntaxKind::TokenLBracket
+                            | SyntaxKind::TokenRBracket => continue,
+                            _ => self.visit_element(content, &mut output),
                         }
-                        return Some(output.trim().to_string());
                     }
-                    required_count += 1;
+                    return Some(output.trim().to_string());
                 }
+                required_count += 1;
             }
         }
         None

--- a/src/core/latex2typst/context.rs
+++ b/src/core/latex2typst/context.rs
@@ -392,6 +392,31 @@ pub struct LatexConverter {
     pub(crate) spec: CommandSpec,
 }
 
+/// A `ClauseArgument` is a *required* argument iff it does not carry an
+/// optional-bracket payload. This covers both braced (`{...}`) and unbraced
+/// single-token forms (`\frac 12`, `\frac\alpha\beta`, `\hat x`).
+///
+/// Two signals indicate a *non*-required (optional `[...]`) clause:
+///   - the clause has an `ItemBracket` child (well-formed `[...]`)
+///   - or the clause's first token is `[`, which happens when mitex parses a
+///     command from the merged spec where the user wrote `[` without a matching
+///     `]` consumable within the argument boundary (e.g. `\citep[see]{a}` - the
+///     `[see]` is not part of the required-arg slot in mitex's spec, so the
+///     parser emits a `ClauseArgument` containing only the bare `[` token).
+///     We must reject this case, or downstream code mistakes `"["` for the
+///     real required argument and the citation handler in `markup.rs` is
+///     bypassed.
+fn is_required_clause(child: &SyntaxNode) -> bool {
+    child.kind() == SyntaxKind::ClauseArgument
+        && !child
+            .children()
+            .any(|c| c.kind() == SyntaxKind::ItemBracket)
+        && !matches!(
+            child.first_token().map(|t| t.kind()),
+            Some(SyntaxKind::TokenLBracket)
+        )
+}
+
 impl LatexConverter {
     /// Create a new converter with default options
     pub fn new() -> Self {
@@ -897,15 +922,7 @@ impl LatexConverter {
     pub fn get_required_arg(&self, cmd: &CmdItem, index: usize) -> Option<String> {
         let mut required_count = 0;
         for child in cmd.syntax().children() {
-            if child.kind() == SyntaxKind::ClauseArgument
-                && !child
-                    .children()
-                    .any(|c| c.kind() == SyntaxKind::ItemBracket)
-                && !matches!(
-                    child.first_token().map(|t| t.kind()),
-                    Some(SyntaxKind::TokenLBracket)
-                )
-            {
+            if is_required_clause(&child) {
                 if required_count == index {
                     return Some(extract_arg_content(&child));
                 }
@@ -919,15 +936,7 @@ impl LatexConverter {
     pub fn get_required_arg_with_braces(&self, cmd: &CmdItem, index: usize) -> Option<String> {
         let mut required_count = 0;
         for child in cmd.syntax().children() {
-            if child.kind() == SyntaxKind::ClauseArgument
-                && !child
-                    .children()
-                    .any(|c| c.kind() == SyntaxKind::ItemBracket)
-                && !matches!(
-                    child.first_token().map(|t| t.kind()),
-                    Some(SyntaxKind::TokenLBracket)
-                )
-            {
+            if is_required_clause(&child) {
                 if required_count == index {
                     return Some(extract_arg_content_with_braces(&child));
                 }
@@ -960,15 +969,7 @@ impl LatexConverter {
     pub fn convert_required_arg(&mut self, cmd: &CmdItem, index: usize) -> Option<String> {
         let mut required_count = 0;
         for child in cmd.syntax().children() {
-            if child.kind() == SyntaxKind::ClauseArgument
-                && !child
-                    .children()
-                    .any(|c| c.kind() == SyntaxKind::ItemBracket)
-                && !matches!(
-                    child.first_token().map(|t| t.kind()),
-                    Some(SyntaxKind::TokenLBracket)
-                )
-            {
+            if is_required_clause(&child) {
                 if required_count == index {
                     let mut output = String::new();
                     for content in child.children_with_tokens() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,6 +269,27 @@ mod tests {
     }
 
     #[test]
+    fn test_latex_to_typst_unbraced_command_args_extended() {
+        // Command tokens as required args - the bug went wider than \frac/\sqrt:
+        // any command taking a required arg was skipped when given an unbraced
+        // command token (before the fix, the converter only counted braced args).
+        assert_eq!(latex_to_typst(r"\frac\alpha\beta"), "alpha/ beta");
+        assert_eq!(latex_to_typst(r"\frac\alpha 2"), "alpha/2");
+        assert_eq!(latex_to_typst(r"\sqrt\alpha"), "sqrt(alpha)");
+
+        // Accent / over-line commands with unbraced single token
+        assert_eq!(latex_to_typst(r"\hat x"), "hat(x)");
+        assert_eq!(latex_to_typst(r"\overline x"), "overline(x)");
+
+        // Optional bracket arg + unbraced required arg combination
+        assert_eq!(latex_to_typst(r"\sqrt[3]2"), "root(3, 2)");
+        assert_eq!(latex_to_typst(r"\sqrt[3]{8}"), "root(3, 8)");
+
+        // \binom with unbraced args
+        assert_eq!(latex_to_typst(r"\binom n k"), "binom(n, k)");
+    }
+
+    #[test]
     fn test_typst_to_latex_basic() {
         let result = typst_to_latex("alpha + beta");
         assert!(result.contains("alpha"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,6 +257,18 @@ mod tests {
     }
 
     #[test]
+    fn test_latex_to_typst_unbraced_command_args() {
+        assert_eq!(latex_to_typst(r"\frac 12"), "1/2");
+        assert_eq!(latex_to_typst(r"\frac 1{1-A}"), "frac(1, 1 - A)");
+        assert_eq!(latex_to_typst(r"\frac {1-A}A"), "frac(1 - A, A)");
+        assert_eq!(latex_to_typst(r"\frac {A+2}{1-A}"), "frac(A + 2, 1 - A)");
+        assert_eq!(latex_to_typst(r"\sqrt 2"), "sqrt(2)");
+        assert_eq!(latex_to_typst(r"\sqrt 12"), "sqrt(1)2");
+        assert_eq!(latex_to_typst(r"\sqrt {12}"), "sqrt(1 2)");
+        assert_eq!(latex_to_typst(r"\sqrt{12}"), "sqrt(1 2)");
+    }
+
+    #[test]
     fn test_typst_to_latex_basic() {
         let result = typst_to_latex("alpha + beta");
         assert!(result.contains("alpha"));


### PR DESCRIPTION
## Description

Fixes conversion of valid LaTeX commands whose required arguments are provided as single unbraced tokens.

Examples include `\frac 12`, `\frac 1{1-A}`, `\sqrt 2`, and `\sqrt 12`. These arguments are parsed as command arguments, but the converter only counted braced `ItemCurly` arguments when extracting required args, so unbraced arguments could be skipped or shifted.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [x] Tests pass (`cargo test`)
- [x] No clippy warnings (`cargo clippy`)
- [x] Code formatted (`cargo fmt`)
- [x] Documentation updated (if needed)
