### PR TITLE
Fix/math symbol grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7] - 2026-07-18
+
+### Fixed
+- **L2T math**: fixed literal slash (`/` to `slash`), brace annotations (`underbrace(x, y)` / `overbrace(x, y)`), escaped commas in `cases`, and current Typst `.o` spellings for circled operators.
+- **L2T commands**: `\hspace`, `\hspace*`, `\vspace`, and `\vspace*` consume dimension arguments; `\hyperref[target]{text}` emits `#link(<target>)[text]`.
+- **L2T physics**: bra-ket commands (`\ket`, `\bra`, `\braket`, `\dyad`, `\expval`, `\mel`, ...) use valid `chevron.l` / `chevron.r` delimiters.
+- **References**: multi-key `\cite{a,b}` splits into separate Typst `#cite(...)` calls, with shared postnotes attached to the last key.
+- **Greek variants**: `\epsilon` / `\varepsilon` map to Typst `epsilon.alt` / `epsilon`, with matching T2L reverse mappings.
+- **T2L line breaks**: aligned Typst math line breaks emit LaTeX `\\`, including from the WASM/web math entrypoint, while inline fragments keep a bare `\`.
+
 ## [0.3.6] - 2026-05-05
 
 ### Fixed
@@ -138,7 +148,8 @@ This release is a major overhaul of the core conversion logic, introducing prope
 - CLI tool (`t2l`)
 - Structured error handling with warnings
 
-[Unreleased]: https://github.com/scipenai/tylax/compare/v0.3.6...HEAD
+[Unreleased]: https://github.com/scipenai/tylax/compare/v0.3.7...HEAD
+[0.3.7]: https://github.com/scipenai/tylax/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/scipenai/tylax/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/scipenai/tylax/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/scipenai/tylax/compare/v0.3.3...v0.3.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,7 +1255,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tylax"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "chrono",
  "clap",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "tylax-python"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "pyo3",
  "tylax",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["."]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.6"
+version = "0.3.7"
 
 [package]
 name = "tylax"

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ t2l tikz input.tex -o output.typ
 Add to `Cargo.toml`:
 ```toml
 [dependencies]
-tylax = "0.3.0"
+tylax = "0.3.7"
 ```
 
 ```rust

--- a/README_CN.md
+++ b/README_CN.md
@@ -68,7 +68,7 @@ t2l tikz input.tex -o output.typ
 在 `Cargo.toml` 中添加：
 ```toml
 [dependencies]
-tylax = "0.3.0"
+tylax = "0.3.7"
 ```
 
 ```rust

--- a/src/core/latex2typst/context.rs
+++ b/src/core/latex2typst/context.rs
@@ -4,12 +4,14 @@
 
 use mitex_parser::syntax::{CmdItem, SyntaxElement, SyntaxKind, SyntaxNode};
 use mitex_parser::CommandSpec;
+use mitex_spec::CommandSpecItem;
 use mitex_spec_gen::DEFAULT_SPEC;
 use rowan::ast::AstNode;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 
 use crate::data::constants::{AcronymDef, GlossaryDef};
+use crate::data::extended_symbols::EXTENDED_SYMBOLS;
 use crate::data::maps::TEX_COMMAND_SPEC;
 use crate::features::refs::{CitationMode, ReferenceType};
 use fxhash::FxHashMap;
@@ -251,6 +253,8 @@ pub struct ConversionState {
     pub pending_citation: Option<PendingCitation>,
     /// Pending reference state
     pub pending_reference: Option<PendingReference>,
+    /// Suppress the next raw whitespace token after emitting a spacing-aware token.
+    pub suppress_next_space: bool,
     /// User-defined macros
     pub macros: HashMap<String, MacroDef>,
     /// Whether we're in preamble
@@ -415,6 +419,137 @@ fn is_required_clause(child: &SyntaxNode) -> bool {
             child.first_token().map(|t| t.kind()),
             Some(SyntaxKind::TokenLBracket)
         )
+}
+
+fn slash_is_between_mathy(elem: SyntaxElement) -> bool {
+    let Some(prev) = nearest_non_trivia_sibling(&elem, false) else {
+        return false;
+    };
+    let Some(next) = nearest_non_trivia_sibling(&elem, true) else {
+        return false;
+    };
+
+    elements_form_math_slash(&prev, &next)
+}
+
+fn nearest_non_trivia_sibling(elem: &SyntaxElement, next: bool) -> Option<SyntaxElement> {
+    let mut sibling = if next {
+        elem.next_sibling_or_token()
+    } else {
+        elem.prev_sibling_or_token()
+    };
+
+    while let Some(current) = sibling {
+        if !matches!(
+            current.kind(),
+            SyntaxKind::TokenWhiteSpace | SyntaxKind::TokenLineBreak | SyntaxKind::TokenComment
+        ) {
+            return Some(current);
+        }
+        sibling = if next {
+            current.next_sibling_or_token()
+        } else {
+            current.prev_sibling_or_token()
+        };
+    }
+
+    None
+}
+
+fn element_is_mathy(elem: &SyntaxElement) -> bool {
+    match elem.kind() {
+        SyntaxKind::ItemLR | SyntaxKind::ItemAttachComponent => true,
+        SyntaxKind::ItemCmd => {
+            let Some(node) = elem.as_node() else {
+                return false;
+            };
+            let Some(cmd) = CmdItem::cast(node.clone()) else {
+                return false;
+            };
+            let Some(name) = cmd.name_tok() else {
+                return false;
+            };
+            command_is_math_like(name.text().trim_start_matches('\\'))
+        }
+        _ => false,
+    }
+}
+
+fn command_is_math_like(name: &str) -> bool {
+    let base_name = name.strip_suffix('*').unwrap_or(name);
+
+    if let Some(CommandSpecItem::Cmd(shape)) = TEX_COMMAND_SPEC.get(name) {
+        if shape.alias.is_some() {
+            return true;
+        }
+    }
+
+    if EXTENDED_SYMBOLS.contains_key(name) || EXTENDED_SYMBOLS.contains_key(base_name) {
+        return true;
+    }
+
+    matches!(
+        base_name,
+        "abs"
+            | "absolutevalue"
+            | "bar"
+            | "binom"
+            | "bm"
+            | "boldsymbol"
+            | "bra"
+            | "braket"
+            | "cfrac"
+            | "dfrac"
+            | "dyad"
+            | "ev"
+            | "expval"
+            | "expectationvalue"
+            | "flatfrac"
+            | "frac"
+            | "hat"
+            | "innerproduct"
+            | "ip"
+            | "ket"
+            | "ketbra"
+            | "matrixel"
+            | "matrixelement"
+            | "matrixquantity"
+            | "mathbb"
+            | "mathbf"
+            | "mathcal"
+            | "mathfrak"
+            | "mathit"
+            | "mathop"
+            | "mathrm"
+            | "mathsf"
+            | "mathtt"
+            | "mel"
+            | "norm"
+            | "op"
+            | "outerproduct"
+            | "overbrace"
+            | "overline"
+            | "overset"
+            | "qty"
+            | "sqrt"
+            | "stackrel"
+            | "tilde"
+            | "tfrac"
+            | "underbrace"
+            | "underset"
+            | "vec"
+            | "widehat"
+            | "widetilde"
+    )
+}
+
+fn elements_form_math_slash(prev: &SyntaxElement, next: &SyntaxElement) -> bool {
+    let prev_mathy = element_is_mathy(prev);
+    let next_mathy = element_is_mathy(next);
+    let prev_word = prev.kind() == SyntaxKind::TokenWord;
+    let next_word = next.kind() == SyntaxKind::TokenWord;
+
+    (prev_mathy && (next_mathy || next_word)) || (prev_word && next_mathy)
 }
 
 impl LatexConverter {
@@ -720,6 +855,10 @@ impl LatexConverter {
             return;
         }
 
+        if self.state.suppress_next_space && !matches!(elem.kind(), SyntaxKind::TokenWhiteSpace) {
+            self.state.suppress_next_space = false;
+        }
+
         match elem.kind() {
             // Handle errors gracefully
             TokenError => {
@@ -804,7 +943,11 @@ impl LatexConverter {
             // Whitespace
             TokenWhiteSpace => {
                 if let SyntaxElement::Token(t) = elem {
-                    output.push_str(t.text());
+                    if self.state.suppress_next_space {
+                        self.state.suppress_next_space = false;
+                    } else {
+                        output.push_str(t.text());
+                    }
                 }
             }
 
@@ -876,7 +1019,17 @@ impl LatexConverter {
                     output.push(',');
                 }
             }
-            TokenSlash => output.push('/'),
+            TokenSlash => {
+                if matches!(self.state.mode, ConversionMode::Math) || slash_is_between_mathy(elem) {
+                    while output.ends_with(char::is_whitespace) {
+                        output.pop();
+                    }
+                    output.push_str(" slash ");
+                    self.state.suppress_next_space = true;
+                } else {
+                    output.push('/');
+                }
+            }
             TokenAsterisk => {
                 if let Some(ref mut op) = self.state.pending_op {
                     op.is_limits = true;

--- a/src/core/latex2typst/markup.rs
+++ b/src/core/latex2typst/markup.rs
@@ -21,7 +21,7 @@ use super::context::{
     ConversionMode, EnvironmentContext, LatexConverter, MacroDef, PendingCitation, PendingOperator,
     PendingReference,
 };
-use super::utils::{contains_top_level_separator, sanitize_label, to_roman_numeral};
+use super::utils::{protect_top_level_comma, sanitize_label, to_roman_numeral};
 use crate::features::images::ImageAttributes;
 use crate::features::refs::{
     citation_mode_from_latex_command, citation_to_typst, label_to_typst, reference_to_typst,
@@ -109,6 +109,13 @@ fn extract_wrapped_operator_name(arg: &str) -> Option<String> {
     if let Some(inner) = trimmed
         .strip_prefix('"')
         .and_then(|rest| rest.strip_suffix('"'))
+    {
+        return normalize_operator_name_text(inner);
+    }
+
+    if let Some(inner) = trimmed
+        .strip_prefix("#text[")
+        .and_then(|rest| rest.strip_suffix(']'))
     {
         return normalize_operator_name_text(inner);
     }
@@ -347,24 +354,6 @@ fn lookup_symbol(name: &str) -> Option<&'static str> {
     None
 }
 
-/// Protect content that contains commas by wrapping in `{}`.
-///
-/// In Typst function calls like `sqrt(content)`, a comma inside `content`
-/// would be parsed as an argument separator. Wrapping with `{}` prevents this:
-/// - `sqrt(a, b)` → parsed as 2 arguments (error for sqrt)
-/// - `sqrt({a, b})` → parsed as 1 argument containing "a, b"
-///
-/// This function only adds `{}` when necessary (when content contains `,`).
-#[inline]
-fn protect_comma(content: &str) -> String {
-    let trimmed = content.trim();
-    if contains_top_level_separator(trimmed, ',') {
-        format!("{{{}}}", trimmed)
-    } else {
-        trimmed.to_string()
-    }
-}
-
 /// Convert a LaTeX command
 pub fn convert_command(conv: &mut LatexConverter, elem: SyntaxElement, output: &mut String) {
     let node = match &elem {
@@ -584,7 +573,11 @@ pub fn convert_command(conv: &mut LatexConverter, elem: SyntaxElement, output: &
         // Text in math - these commands output text in math mode
         "text" | "textrm" | "textup" | "textnormal" => {
             if let Some(arg) = conv.get_required_arg(&cmd, 0) {
-                let _ = write!(output, "\"{}\" ", arg);
+                if matches!(conv.state.mode, ConversionMode::Math) {
+                    let _ = write!(output, "#text[{}] ", arg);
+                } else {
+                    output.push_str(&arg);
+                }
             }
         }
 
@@ -818,7 +811,7 @@ pub fn convert_command(conv: &mut LatexConverter, elem: SyntaxElement, output: &
         "sqrt" => {
             let opt = conv.get_optional_arg(&cmd, 0);
             let content = conv.convert_required_arg(&cmd, 0).unwrap_or_default();
-            let protected = protect_comma(&content);
+            let protected = protect_top_level_comma(&content);
             if let Some(n) = opt {
                 let _ = write!(output, "root({}, {})", n, protected);
             } else {
@@ -1419,25 +1412,27 @@ pub fn convert_command(conv: &mut LatexConverter, elem: SyntaxElement, output: &
         "ket" | "ket*" => {
             // \ket{ψ} → lr(| ψ ⟩)
             if let Some(content) = conv.convert_required_arg(&cmd, 0) {
-                let _ = write!(output, "lr(| {} angle.r)", content.trim());
+                let _ = write!(output, "lr(| {} chevron.r)", content.trim());
             }
         }
         "bra" | "bra*" => {
             // \bra{ψ} → lr(⟨ ψ |)
             if let Some(content) = conv.convert_required_arg(&cmd, 0) {
-                let _ = write!(output, "lr(angle.l {} |)", content.trim());
+                let _ = write!(output, "lr(chevron.l {} |)", content.trim());
             }
         }
         "braket" | "innerproduct" | "ip" | "braket*" => {
             // \braket{a}{b} → lr(⟨ a | b ⟩)
             // \braket{a} → lr(⟨ a | a ⟩)
             let a = conv.convert_required_arg(&cmd, 0).unwrap_or_default();
-            let b = conv.convert_required_arg(&cmd, 1);
+            let b = conv
+                .convert_required_arg(&cmd, 1)
+                .filter(|value| !value.trim().is_empty());
             match b {
                 Some(b) => {
                     let _ = write!(
                         output,
-                        "lr(angle.l {} | {} angle.r)",
+                        "lr(chevron.l {} | {} chevron.r)",
                         a.trim(), b.trim()
                     );
                 }
@@ -1445,7 +1440,7 @@ pub fn convert_command(conv: &mut LatexConverter, elem: SyntaxElement, output: &
                     let a_trimmed = a.trim();
                     let _ = write!(
                         output,
-                        "lr(angle.l {} | {} angle.r)",
+                        "lr(chevron.l {} | {} chevron.r)",
                         a_trimmed, a_trimmed
                     );
                 }
@@ -1459,7 +1454,7 @@ pub fn convert_command(conv: &mut LatexConverter, elem: SyntaxElement, output: &
             let b_val = b.as_deref().unwrap_or(a.trim());
             let _ = write!(
                 output,
-                "lr(| {} angle.r) lr(angle.l {} |)",
+                "lr(| {} chevron.r) lr(chevron.l {} |)",
                 a.trim(), b_val.trim()
             );
         }
@@ -1472,14 +1467,14 @@ pub fn convert_command(conv: &mut LatexConverter, elem: SyntaxElement, output: &
                 Some(psi) => {
                     let _ = write!(
                         output,
-                        "lr(angle.l {} | {} | {} angle.r)",
+                        "lr(chevron.l {} | {} | {} chevron.r)",
                         psi.trim(), op.trim(), psi.trim()
                     );
                 }
                 None => {
                     let _ = write!(
                         output,
-                        "lr(angle.l {} angle.r)",
+                        "lr(chevron.l {} chevron.r)",
                         op.trim()
                     );
                 }
@@ -1490,7 +1485,7 @@ pub fn convert_command(conv: &mut LatexConverter, elem: SyntaxElement, output: &
             if let Some(op) = conv.convert_required_arg(&cmd, 0) {
                 let _ = write!(
                     output,
-                    "lr(angle.l 0 | {} | 0 angle.r)",
+                    "lr(chevron.l 0 | {} | 0 chevron.r)",
                     op.trim()
                 );
             }
@@ -1502,7 +1497,7 @@ pub fn convert_command(conv: &mut LatexConverter, elem: SyntaxElement, output: &
             let m = conv.convert_required_arg(&cmd, 2).unwrap_or_default();
             let _ = write!(
                 output,
-                "lr(angle.l {} | {} | {} angle.r)",
+                "lr(chevron.l {} | {} | {} chevron.r)",
                 n.trim(), a.trim(), m.trim()
             );
         }
@@ -2048,8 +2043,8 @@ pub fn convert_command(conv: &mut LatexConverter, elem: SyntaxElement, output: &
         "oint" => output.push_str("integral.cont "),
         "bigcup" => output.push_str("union.big "),
         "bigcap" => output.push_str("sect.big "),
-        "bigoplus" => output.push_str("plus.circle.big "),
-        "bigotimes" => output.push_str("times.circle.big "),
+        "bigoplus" => output.push_str("plus.o.big "),
+        "bigotimes" => output.push_str("times.o.big "),
         "bigsqcup" => output.push_str("union.sq.big "),
         "biguplus" => output.push_str("union.plus.big "),
         "bigvee" => output.push_str("or.big "),

--- a/src/core/latex2typst/math.rs
+++ b/src/core/latex2typst/math.rs
@@ -2,12 +2,13 @@
 //!
 //! This module handles math formulas, delimiters, and math-specific constructs.
 
-use mitex_parser::syntax::{FormulaItem, SyntaxElement, SyntaxKind, SyntaxNode};
+use mitex_parser::syntax::{CmdItem, FormulaItem, SyntaxElement, SyntaxKind, SyntaxNode};
 use rowan::ast::AstNode;
 use std::fmt::Write;
 
 use super::context::{ConversionMode, LatexConverter};
 use super::environment::{convert_array_with_delim, convert_matrix_with_delim};
+use super::utils::protect_top_level_comma;
 
 /// Convert a math formula ($..$ or $$..$$)
 pub fn convert_formula(conv: &mut LatexConverter, elem: SyntaxElement, output: &mut String) {
@@ -506,6 +507,15 @@ pub fn convert_attachment(conv: &mut LatexConverter, elem: SyntaxElement, output
         _ => return,
     };
 
+    // `\underbrace{body}_{label}` / `\overbrace{body}^{label}` parse as an
+    // attachment whose nucleus is the brace command and whose script is the
+    // label. Typst takes the label as a second positional argument, so fold it
+    // in (`underbrace(body, label)`) instead of emitting a literal script.
+    if let Some(folded) = fold_brace_annotation(conv, &node) {
+        output.push_str(&folded);
+        return;
+    }
+
     let mut is_script = false;
 
     for child in node.children_with_tokens() {
@@ -543,6 +553,89 @@ pub fn convert_attachment(conv: &mut LatexConverter, elem: SyntaxElement, output
             conv.visit_element(child, output);
         }
     }
+}
+
+/// Fold a `\underbrace`/`\overbrace` brace annotation into Typst's second
+/// positional argument.
+///
+/// The attachment parses as `ItemAttachComponent[ ClauseArgument[ ItemCmd ],
+/// marker, script ]`, where the nucleus is the brace command and the script is
+/// the label. Emitting it verbatim yields `underbrace(body)_(label)`, which
+/// renders the label as a real subscript instead of the brace label; Typst
+/// expects `underbrace(body, label)`.
+///
+/// Only the canonical pairings fold: `\underbrace` with `_`, `\overbrace` with
+/// `^`. Any other shape (non-brace nucleus, the opposite/extra script) returns
+/// `None` so the generic attachment handling applies unchanged.
+fn fold_brace_annotation(conv: &mut LatexConverter, node: &SyntaxNode) -> Option<String> {
+    let mut nucleus: Option<SyntaxNode> = None;
+    let mut marker: Option<SyntaxKind> = None;
+    let mut script: Option<SyntaxElement> = None;
+
+    for child in node.children_with_tokens() {
+        match child.kind() {
+            SyntaxKind::TokenWhiteSpace | SyntaxKind::TokenLineBreak => continue,
+            kind @ (SyntaxKind::TokenUnderscore | SyntaxKind::TokenCaret) => {
+                if marker.is_some() {
+                    return None; // a second script (e.g. `_a^b`): not a plain label
+                }
+                marker = Some(kind);
+            }
+            _ if marker.is_none() => {
+                if nucleus.is_some() {
+                    return None; // unexpected extra content before the script
+                }
+                nucleus = Some(child.into_node()?);
+            }
+            _ => {
+                if script.is_some() {
+                    return None; // unexpected extra content after the script
+                }
+                script = Some(child);
+            }
+        }
+    }
+
+    let marker = marker?;
+    // The nucleus command is wrapped in a `ClauseArgument`; descend to the
+    // `ItemCmd` (also accept a bare `ItemCmd` defensively).
+    let nucleus = nucleus?;
+    let cmd_node = if nucleus.kind() == SyntaxKind::ItemCmd {
+        nucleus
+    } else {
+        nucleus
+            .children()
+            .find(|n| n.kind() == SyntaxKind::ItemCmd)?
+    };
+    let cmd = CmdItem::cast(cmd_node)?;
+    let name = cmd.name_tok()?.text().trim_start_matches('\\').to_string();
+
+    // Non-canonical pairings (e.g. `\underbrace{..}^{..}`) are returned to the
+    // generic attachment handler untouched. We bail out *before* converting so
+    // that path sees an unconsumed nucleus/script.
+    let folds = matches!(
+        (name.as_str(), marker),
+        ("underbrace", SyntaxKind::TokenUnderscore) | ("overbrace", SyntaxKind::TokenCaret)
+    );
+    if !folds {
+        return None;
+    }
+
+    let script = script?;
+    let body = conv.convert_required_arg(&cmd, 0)?;
+    let previous_mode = conv.state.mode;
+    conv.state.mode = ConversionMode::Math;
+    let mut label = String::new();
+    conv.visit_element(script, &mut label);
+    conv.state.mode = previous_mode;
+
+    // A top-level comma in either operand would be read as an extra positional
+    // argument to the brace function; wrap such operands in `{}` so each stays a
+    // single argument (same protection used for `sqrt`, `root`, ...).
+    let body = protect_top_level_comma(&body);
+    let label = protect_top_level_comma(&label);
+
+    Some(format!("{}({}, {}) ", name, body, label))
 }
 
 // =============================================================================

--- a/src/core/latex2typst/utils.rs
+++ b/src/core/latex2typst/utils.rs
@@ -269,9 +269,22 @@ pub fn contains_top_level_separator(text: &str, separator: char) -> bool {
     let mut paren_depth = 0usize;
     let mut bracket_depth = 0usize;
     let mut brace_depth = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
 
     for ch in text.chars() {
+        if in_string {
+            match ch {
+                _ if escaped => escaped = false,
+                '\\' => escaped = true,
+                '"' => in_string = false,
+                _ => {}
+            }
+            continue;
+        }
+
         match ch {
+            '"' => in_string = true,
             '(' => paren_depth += 1,
             ')' if paren_depth > 0 => paren_depth -= 1,
             '[' => bracket_depth += 1,
@@ -287,6 +300,20 @@ pub fn contains_top_level_separator(text: &str, separator: char) -> bool {
     }
 
     false
+}
+
+/// Protect content that contains a top-level comma by wrapping it in `{}`.
+///
+/// Typst function calls treat top-level commas as argument separators, so
+/// `sqrt(a, b)` is parsed as two arguments while `sqrt({a, b})` is a single
+/// content argument.
+pub fn protect_top_level_comma(content: &str) -> String {
+    let trimmed = content.trim();
+    if contains_top_level_separator(trimmed, ',') {
+        format!("{{{}}}", trimmed)
+    } else {
+        trimmed.to_string()
+    }
 }
 
 // =============================================================================

--- a/src/core/typst2latex/context.rs
+++ b/src/core/typst2latex/context.rs
@@ -180,6 +180,11 @@ pub struct ConvertContext {
     pub variables: HashMap<String, String>,
     /// Pending label to be attached to the next figure/table environment
     pub pending_label: Option<String>,
+    /// Whether a math line break (`\`) should render as LaTeX's `\\` row
+    /// separator. Defaults to false because new contexts often render inline
+    /// fragments (scripts, matrix cells, function arguments); row-level callers
+    /// opt in explicitly.
+    pub linebreak_as_row: bool,
 }
 
 /// Initial capacity for output buffer (reduces reallocations)
@@ -201,6 +206,7 @@ impl ConvertContext {
             warnings: Vec::new(),
             variables: HashMap::new(),
             pending_label: None,
+            linebreak_as_row: false,
         }
     }
 
@@ -219,6 +225,7 @@ impl ConvertContext {
             warnings: Vec::new(),
             variables: HashMap::new(),
             pending_label: None,
+            linebreak_as_row: false,
         }
     }
 

--- a/src/core/typst2latex/markup.rs
+++ b/src/core/typst2latex/markup.rs
@@ -220,7 +220,12 @@ pub fn convert_content_nodes_to_latex(nodes: &[ContentNode], ctx: &mut ConvertCo
             ContentNode::Math { segments, block } => {
                 flush_typst_chunk(&mut buffer, ctx);
                 let math_source = render_math_segments_to_typst_source(segments);
-                let math_content = convert_math_source_to_latex(&math_source, &ctx.options);
+                let math_content = convert_math_source_to_latex(&math_source, &ctx.options, false);
+                let math_content = rerender_math_with_row_linebreaks_if_aligned(
+                    &math_source,
+                    &ctx.options,
+                    math_content,
+                );
                 emit_rendered_math(ctx, &math_content, *block);
             }
             other => buffer.push_str(&other.to_typst()),
@@ -230,14 +235,60 @@ pub fn convert_content_nodes_to_latex(nodes: &[ContentNode], ctx: &mut ConvertCo
     flush_typst_chunk(&mut buffer, ctx);
 }
 
-fn convert_math_source_to_latex(math_source: &str, options: &T2LOptions) -> String {
+fn convert_math_source_to_latex(
+    math_source: &str,
+    options: &T2LOptions,
+    linebreak_as_row: bool,
+) -> String {
     let wrapped = format!("${}$", math_source);
     let root = typst_syntax::parse(&wrapped);
     let mut math_ctx = ConvertContext::new();
     math_ctx.options = options.clone();
     math_ctx.in_math = true;
+    math_ctx.linebreak_as_row = linebreak_as_row;
     convert_first_math_child(&root, &mut math_ctx);
     math_ctx.finalize().trim().to_string()
+}
+
+fn rerender_math_with_row_linebreaks_if_aligned(
+    math_source: &str,
+    options: &T2LOptions,
+    rendered: String,
+) -> String {
+    if rendered.contains(" \\\n") && has_unescaped_alignment(&rendered) {
+        convert_math_source_to_latex(math_source, options, true)
+    } else {
+        rendered
+    }
+}
+
+fn convert_equation_math_to_latex(
+    node: &SyntaxNode,
+    options: &T2LOptions,
+    linebreak_as_row: bool,
+) -> String {
+    let mut math_ctx = ConvertContext::new();
+    math_ctx.options = options.clone();
+    math_ctx.in_math = true;
+    math_ctx.linebreak_as_row = linebreak_as_row;
+    for child in node.children() {
+        if child.kind() == SyntaxKind::Math {
+            convert_math_node(child, &mut math_ctx);
+        }
+    }
+    math_ctx.finalize().trim().to_string()
+}
+
+fn rerender_equation_with_row_linebreaks_if_aligned(
+    node: &SyntaxNode,
+    options: &T2LOptions,
+    rendered: String,
+) -> String {
+    if rendered.contains(" \\\n") && has_unescaped_alignment(&rendered) {
+        convert_equation_math_to_latex(node, options, true)
+    } else {
+        rendered
+    }
 }
 
 fn convert_first_math_child(node: &SyntaxNode, ctx: &mut ConvertContext) -> bool {
@@ -268,18 +319,27 @@ fn is_listings_supported(lang: &str) -> bool {
 fn has_unescaped_alignment(content: &str) -> bool {
     // Count nesting level of cases/matrix environments
     let mut depth = 0;
+    let mut brace_depth = 0;
     let mut chars = content.chars().peekable();
 
     while let Some(ch) = chars.next() {
         if ch == '\\' {
-            // Check for \begin or \end
+            // Check for \begin or \end before treating the next character as an
+            // escaped literal (for example `\&`, which is not an alignment
+            // marker).
             let rest: String = chars.clone().take(5).collect();
             if rest.starts_with("begin") {
                 depth += 1;
             } else if rest.starts_with("end") && depth > 0 {
                 depth -= 1;
+            } else {
+                let _ = chars.next();
             }
-        } else if ch == '&' && depth == 0 {
+        } else if ch == '{' {
+            brace_depth += 1;
+        } else if ch == '}' && brace_depth > 0 {
+            brace_depth -= 1;
+        } else if ch == '&' && depth == 0 && brace_depth == 0 {
             // Found an alignment marker outside of any environment
             return true;
         }
@@ -582,15 +642,12 @@ pub fn convert_markup_node(node: &SyntaxNode, ctx: &mut ConvertContext) {
             let in_table = ctx.is_in_env(&EnvironmentContext::Table);
             let is_block = !in_table && is_display_math(node);
 
-            // Convert math content to a temporary buffer first
-            let mut math_ctx = ConvertContext::new();
-            math_ctx.in_math = true;
-            for child in node.children() {
-                if child.kind() == SyntaxKind::Math {
-                    convert_math_node(child, &mut math_ctx);
-                }
-            }
-            let math_content = math_ctx.finalize().trim().to_string();
+            // Convert math content to a temporary buffer first. Start with
+            // inline-fragment linebreaks, then re-render with LaTeX row
+            // separators only when the expression is actually aligned.
+            let math_content = convert_equation_math_to_latex(node, &ctx.options, false);
+            let math_content =
+                rerender_equation_with_row_linebreaks_if_aligned(node, &ctx.options, math_content);
 
             emit_rendered_math(ctx, &math_content, is_block);
         }

--- a/src/core/typst2latex/math_emit.rs
+++ b/src/core/typst2latex/math_emit.rs
@@ -501,7 +501,15 @@ fn emit_case_row(row: &MathCaseRow, ctx: &mut ConvertContext) {
 }
 
 fn emit_linebreak(ctx: &mut ConvertContext) {
-    emit_raw_literal(" \\\n", ctx);
+    // A Typst math line break (`\`) maps to LaTeX's `\\` row separator in a row
+    // context (`align`, top-level display). Inside an inline fragment (script,
+    // matrix cell, argument) a `\\` would be invalid, so it degrades to a bare
+    // `\` there.
+    if ctx.linebreak_as_row {
+        emit_raw_literal(" \\\\\n", ctx);
+    } else {
+        emit_raw_literal(" \\\n", ctx);
+    }
 }
 
 fn emit_raw_literal(text: &str, ctx: &mut ConvertContext) {
@@ -536,9 +544,32 @@ fn delimiter_token_type(delim: &str, is_open: bool) -> TokenType {
 #[cfg(test)]
 mod tests {
     use super::{
-        can_strip_wrapping_left_right_parens, can_strip_wrapping_plain_parens,
+        can_strip_wrapping_left_right_parens, can_strip_wrapping_plain_parens, emit_math_ir,
         emit_math_ir_to_string, ConvertContext, MathIr, MathSpacing,
     };
+
+    #[test]
+    fn test_linebreak_ir_emits_double_backslash_in_row_context() {
+        // At the top level (align/display rows) a Typst line break becomes
+        // LaTeX's `\\` row separator. emit_math_ir runs on a row-context context.
+        let mut ctx = ConvertContext::new();
+        ctx.in_math = true;
+        ctx.linebreak_as_row = true;
+        emit_math_ir(
+            &MathIr::Seq(vec![
+                MathIr::Ident("a".to_string()),
+                MathIr::Linebreak,
+                MathIr::Ident("b".to_string()),
+            ]),
+            &mut ctx,
+        );
+        let result = ctx.finalize();
+        assert!(
+            result.contains("a \\\\\n") && result.contains("b"),
+            "row-context line break should emit `\\\\`, got: {}",
+            result
+        );
+    }
 
     #[test]
     fn test_linebreak_ir_preserves_plain_math_emission() {
@@ -553,7 +584,7 @@ mod tests {
 
         assert!(
             result.contains("i \\\n") && result.contains("j"),
-            "linebreak IR should still emit a raw LaTeX linebreak in plain math, got: {}",
+            "linebreak inside an inline fragment (to_string) degrades to a bare `\\`, got: {}",
             result
         );
     }

--- a/src/data/maps.rs
+++ b/src/data/maps.rs
@@ -210,15 +210,15 @@ lazy_static! {
         }));
         m.insert("bigodot".to_string(), CommandSpecItem::Cmd(CmdShape {
             args: ArgShape::Right { pattern: ArgPattern::None },
-            alias: Some("dot.circle.big".to_string()),
+            alias: Some("dot.o.big".to_string()),
         }));
         m.insert("bigoplus".to_string(), CommandSpecItem::Cmd(CmdShape {
             args: ArgShape::Right { pattern: ArgPattern::None },
-            alias: Some("plus.circle.big".to_string()),
+            alias: Some("plus.o.big".to_string()),
         }));
         m.insert("bigotimes".to_string(), CommandSpecItem::Cmd(CmdShape {
             args: ArgShape::Right { pattern: ArgPattern::None },
-            alias: Some("times.circle.big".to_string()),
+            alias: Some("times.o.big".to_string()),
         }));
         m.insert("bigsqcup".to_string(), CommandSpecItem::Cmd(CmdShape {
             args: ArgShape::Right { pattern: ArgPattern::None },
@@ -746,7 +746,7 @@ lazy_static! {
         }));
         m.insert("odot".to_string(), CommandSpecItem::Cmd(CmdShape {
             args: ArgShape::Right { pattern: ArgPattern::None },
-            alias: Some("dot.circle".to_string()),
+            alias: Some("dot.o".to_string()),
         }));
         m.insert("oint".to_string(), CommandSpecItem::Cmd(CmdShape {
             args: ArgShape::Right { pattern: ArgPattern::None },
@@ -766,19 +766,19 @@ lazy_static! {
         }));
         m.insert("ominus".to_string(), CommandSpecItem::Cmd(CmdShape {
             args: ArgShape::Right { pattern: ArgPattern::None },
-            alias: Some("minus.circle".to_string()),
+            alias: Some("minus.o".to_string()),
         }));
         m.insert("oplus".to_string(), CommandSpecItem::Cmd(CmdShape {
             args: ArgShape::Right { pattern: ArgPattern::None },
-            alias: Some("plus.circle".to_string()),
+            alias: Some("plus.o".to_string()),
         }));
         m.insert("oslash".to_string(), CommandSpecItem::Cmd(CmdShape {
             args: ArgShape::Right { pattern: ArgPattern::None },
-            alias: Some("divides.circle".to_string()),
+            alias: Some("slash.o".to_string()),
         }));
         m.insert("otimes".to_string(), CommandSpecItem::Cmd(CmdShape {
             args: ArgShape::Right { pattern: ArgPattern::None },
-            alias: Some("times.circle".to_string()),
+            alias: Some("times.o".to_string()),
         }));
         m.insert("parallel".to_string(), CommandSpecItem::Cmd(CmdShape {
             args: ArgShape::Right { pattern: ArgPattern::None },
@@ -2023,6 +2023,16 @@ pub static TYPST_TO_TEX: phf::Map<&'static str, &'static str> = phf_map! {
     "times.circle" => "otimes",
     "times.circle.big" => "bigotimes",
     "dot.circle.big" => "bigodot",
+    // Current Typst circled-operator spelling (`.o`); `.circle` above is the
+    // pre-0.12 deprecated form kept for backward compatibility.
+    "plus.o" => "\\oplus",
+    "plus.o.big" => "\\bigoplus",
+    "minus.o" => "\\ominus",
+    "times.o" => "\\otimes",
+    "times.o.big" => "\\bigotimes",
+    "dot.o" => "\\odot",
+    "dot.o.big" => "\\bigodot",
+    "slash.o" => "\\oslash",
 
     // =========================================================================
     // Relations

--- a/src/features/refs.rs
+++ b/src/features/refs.rs
@@ -264,10 +264,9 @@ pub fn parse_latex_citation(input: &str) -> Option<CiteGroup> {
         (CitationMode::Normal, rest)
     } else if let Some(rest) = input.strip_prefix("\\textcite{") {
         (CitationMode::AuthorInText, rest)
-    } else if let Some(rest) = input.strip_prefix("\\autocite{") {
-        (CitationMode::Normal, rest)
     } else {
-        return None;
+        let rest = input.strip_prefix("\\autocite{")?;
+        (CitationMode::Normal, rest)
     };
 
     // Find closing brace
@@ -406,10 +405,9 @@ pub fn parse_latex_ref(input: &str) -> Option<Reference> {
         (ReferenceType::Named, rest)
     } else if let Some(rest) = input.strip_prefix("\\cref{") {
         (ReferenceType::Named, rest)
-    } else if let Some(rest) = input.strip_prefix("\\Cref{") {
-        (ReferenceType::Named, rest)
     } else {
-        return None;
+        let rest = input.strip_prefix("\\Cref{")?;
+        (ReferenceType::Named, rest)
     };
 
     let end = rest.find('}')?;
@@ -600,37 +598,41 @@ pub fn citation_to_typst(group: &CiteGroup) -> String {
 
     // Citations must remain explicit in Typst.
     // Bare @key is reserved for reference-first semantics on the T2L path.
-    let mut result = String::from("#cite(");
-
-    // Add keys
-    let keys: Vec<String> = group
+    //
+    // Typst's `cite` takes a single key, so multiple LaTeX keys (e.g.
+    // `\cite{a,b}`) must be emitted as separate `#cite(<a>) #cite(<b>)` calls.
+    // Joining keys inside one `#cite(<a>, <b>)` is invalid Typst and fails to
+    // compile.
+    let last = group.citations.len() - 1;
+    let cites: Vec<String> = group
         .citations
         .iter()
-        .map(|c| format!("<{}>", c.key))
+        .enumerate()
+        .map(|(i, c)| {
+            let mut one = format!("#cite(<{}>", c.key);
+
+            // Form is per-citation; biblatex multi-key groups share one mode.
+            match c.mode {
+                CitationMode::AuthorInText => one.push_str(", form: \"prose\""),
+                CitationMode::SuppressAuthor => one.push_str(", form: \"year\""),
+                CitationMode::NoParen => one.push_str(", form: \"author\""),
+                _ => {}
+            }
+
+            // A shared postnote (e.g. page number) has no group-level equivalent
+            // once keys are split, so attach it to the final citation.
+            if i == last {
+                if let Some(ref suffix) = group.suffix {
+                    one.push_str(&format!(", supplement: [{}]", suffix));
+                }
+            }
+
+            one.push(')');
+            one
+        })
         .collect();
-    result.push_str(&keys.join(", "));
 
-    // Add form for non-normal modes
-    let mode = group.citations[0].mode;
-    match mode {
-        CitationMode::AuthorInText => {
-            result.push_str(", form: \"prose\"");
-        }
-        CitationMode::SuppressAuthor => {
-            result.push_str(", form: \"year\"");
-        }
-        CitationMode::NoParen => {
-            result.push_str(", form: \"author\"");
-        }
-        _ => {}
-    }
-
-    // Add supplement for suffix
-    if let Some(ref suffix) = group.suffix {
-        result.push_str(&format!(", supplement: [{}]", suffix));
-    }
-
-    result.push(')');
+    let result = cites.join(" ");
     if let Some(ref prefix) = group.prefix {
         format!("{} {}", prefix, result)
     } else {
@@ -885,6 +887,30 @@ mod tests {
         group.suffix = Some("ch. 2".to_string());
         let typst = citation_to_typst(&group);
         assert_eq!(typst, r#"see #cite(<test2020>, supplement: [ch. 2])"#);
+    }
+
+    #[test]
+    fn test_citation_to_typst_multi_key_splits_calls() {
+        // Typst's `cite` accepts a single key, so multiple keys must become
+        // separate `#cite(..)` calls rather than an invalid `#cite(<a>, <b>)`.
+        let mut group = CiteGroup::new();
+        group.push(Citation::new("a".to_string()));
+        group.push(Citation::new("b".to_string()));
+        assert_eq!(citation_to_typst(&group), r#"#cite(<a>) #cite(<b>)"#);
+    }
+
+    #[test]
+    fn test_citation_to_typst_multi_key_suffix_on_last() {
+        // A shared postnote has no group-level equivalent once keys are split,
+        // so it attaches to the final citation.
+        let mut group = CiteGroup::new();
+        group.push(Citation::new("a".to_string()));
+        group.push(Citation::new("b".to_string()));
+        group.suffix = Some("ch. 2".to_string());
+        assert_eq!(
+            citation_to_typst(&group),
+            r#"#cite(<a>) #cite(<b>, supplement: [ch. 2])"#
+        );
     }
 
     #[test]

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -109,6 +109,69 @@ fn to_js_value<T: Serialize>(value: &T) -> JsValue {
     })
 }
 
+#[cfg(feature = "wasm")]
+fn strip_inline_math_wrapper(output: String) -> String {
+    let trimmed = output.trim();
+    if trimmed.len() >= 2 && trimmed.starts_with('$') && trimmed.ends_with('$') {
+        trimmed[1..trimmed.len() - 1].to_string()
+    } else {
+        output
+    }
+}
+
+#[cfg(feature = "wasm")]
+fn typst_math_to_latex_for_wasm(input: &str, options: &crate::T2LOptions) -> String {
+    if input.contains('&') {
+        let wrapped = format!("${}$", input);
+        let mut markup_options = options.clone();
+        markup_options.math_only = false;
+        return strip_inline_math_wrapper(crate::typst_to_latex_with_options(
+            &wrapped,
+            &markup_options,
+        ));
+    }
+
+    crate::typst_to_latex_with_options(input, options)
+}
+
+#[cfg(all(test, feature = "wasm"))]
+mod tests {
+    use super::typst_math_to_latex_for_wasm;
+
+    fn math_options() -> crate::T2LOptions {
+        crate::T2LOptions {
+            math_only: true,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn wasm_math_align_linebreak_uses_align_environment() {
+        let result = typst_math_to_latex_for_wasm(r"a &= b \ &= c", &math_options());
+        assert!(
+            result.contains(r"\begin{align}") && result.contains("b \\\\"),
+            "aligned bare math should render as a compilable align environment, got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn wasm_math_plain_expression_keeps_bare_math_output() {
+        let result = typst_math_to_latex_for_wasm("frac(1, 2) + alpha", &math_options());
+        assert_eq!(result.trim(), r"\frac{1}{2} + \alpha");
+    }
+
+    #[test]
+    fn wasm_math_cases_ampersands_do_not_become_top_level_align() {
+        let result = typst_math_to_latex_for_wasm("cases(x, & y, z, & w)", &math_options());
+        assert!(
+            result.contains(r"\begin{cases}") && !result.contains(r"\begin{align}"),
+            "cases-internal alignment should stay in cases, got: {}",
+            result
+        );
+    }
+}
+
 /// Conversion result with additional metadata
 #[cfg(feature = "wasm")]
 #[derive(Serialize, Deserialize)]
@@ -154,7 +217,7 @@ pub fn latex_to_typst_wasm(input: &str) -> String {
 #[wasm_bindgen(js_name = "typstToLatex")]
 pub fn typst_to_latex_wasm(input: &str) -> String {
     // Use math_only mode for bare math expressions (without $ delimiters)
-    crate::typst_to_latex_with_options(
+    typst_math_to_latex_for_wasm(
         input,
         &crate::T2LOptions {
             math_only: true,
@@ -295,6 +358,8 @@ pub fn typst_to_latex_with_options_wasm(input: &str, options: JsValue) -> JsValu
         // Math mode (full_document: false) never uses MiniEval for performance.
         if opts.full_document && opts.expand_macros {
             crate::typst_to_latex_with_eval(input, &t2l_opts)
+        } else if !opts.full_document {
+            typst_math_to_latex_for_wasm(input, &t2l_opts)
         } else {
             crate::typst_to_latex_with_options(input, &t2l_opts)
         }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4,8 +4,10 @@ use std::io::Write;
 use std::process::{Command, Stdio};
 
 use tylax::{
-    convert_auto, convert_auto_document, detect_format, latex_document_to_typst, latex_to_typst,
-    typst_to_latex, typst_to_latex_with_diagnostics, typst_to_latex_with_options, T2LOptions,
+    convert_auto, convert_auto_document, detect_format, latex_document_to_typst,
+    latex_document_to_typst_with_options, latex_to_typst, typst_to_latex,
+    typst_to_latex_with_diagnostics, typst_to_latex_with_options, L2TOptions, PreambleMode,
+    T2LOptions,
 };
 
 fn run_t2l_cli(input: &str) -> String {
@@ -368,18 +370,34 @@ mod l2t_math {
     }
 
     #[test]
-    fn test_math_slash_passes_through_literally() {
-        // Math-mode slash escaping (LaTeX `a/b` -> Typst `a\/b`) is intentionally
-        // deferred: it would change every existing user's math output, so it is
-        // tracked separately as an opt-in L2TOptions toggle. Until then `/` is
-        // emitted literally and must NOT be escaped.
-        let inline = latex_to_typst("$a/b$");
-        assert!(inline.contains('/'), "got: {}", inline);
-        assert!(
-            !inline.contains(r"\/"),
-            "slash must not be escaped, got: {}",
-            inline
+    fn test_math_literal_slash_becomes_slash_symbol() {
+        assert_eq!(
+            latex_to_typst(r"\mathbb{R} / \mathbb{Q}").trim(),
+            "RR slash QQ"
         );
+        assert_eq!(latex_to_typst(r"\alpha / x").trim(), "alpha slash x");
+        assert_eq!(latex_to_typst("$a/b$").trim(), "$a slash b$");
+        let no_preamble = L2TOptions {
+            preamble: PreambleMode::None,
+            ..Default::default()
+        };
+        assert_eq!(
+            latex_document_to_typst_with_options(r"\mathbb{R} / \mathbb{Q}", &no_preamble).trim(),
+            "RR slash QQ"
+        );
+        assert_eq!(
+            latex_document_to_typst_with_options("text / path", &no_preamble).trim(),
+            "text / path"
+        );
+        assert_eq!(
+            latex_document_to_typst_with_options(r"\cite{a} / \cite{b}", &no_preamble).trim(),
+            "#cite(<a>) / #cite(<b>)"
+        );
+
+        // `\frac` slash notation is produced by the fraction converter itself,
+        // not by a LaTeX literal `/`, so the existing frac_to_slash option keeps
+        // using Typst's division shorthand for simple fractions.
+        assert_eq!(latex_to_typst(r"\frac{a}b").trim(), "a/b");
     }
 
     #[test]
@@ -650,6 +668,112 @@ mod l2t_math {
     }
 
     #[test]
+    fn test_brace_annotation_folds_into_second_argument() {
+        // `\underbrace{body}_{label}` / `\overbrace{body}^{label}` express the
+        // brace label as a script in LaTeX, but Typst takes it as a second
+        // positional argument. Emitting `underbrace(body)_(label)` would render
+        // the label as a real subscript instead of the brace annotation.
+        assert_eq!(
+            latex_to_typst(r"$\underbrace{a+b}_{c}$").trim(),
+            "$underbrace(a + b, c)$"
+        );
+        assert_eq!(
+            latex_to_typst(r"$\overbrace{x+y}^{n}$").trim(),
+            "$overbrace(x + y, n)$"
+        );
+        // A bare (unbraced) script is folded the same way.
+        assert_eq!(
+            latex_to_typst(r"$\underbrace{a+b}_c$").trim(),
+            "$underbrace(a + b, c)$"
+        );
+        // No script: the single-argument form is preserved unchanged.
+        assert_eq!(
+            latex_to_typst(r"$\underbrace{q}$").trim(),
+            "$underbrace(q)$"
+        );
+        // Non-canonical pairings (underbrace with `^`, overbrace with `_`) are
+        // left as ordinary scripts rather than mis-folded.
+        assert_eq!(
+            latex_to_typst(r"$\underbrace{x}^{y}$").trim(),
+            "$underbrace(x)^(y)$"
+        );
+        assert_eq!(
+            latex_to_typst(r"$\overbrace{x}_{y}$").trim(),
+            "$overbrace(x)_(y)$"
+        );
+    }
+
+    #[test]
+    fn test_brace_annotation_top_level_comma_is_protected() {
+        // A top-level comma in the label/body would make `underbrace(body,
+        // label)` parse as extra positional arguments, so the operand is wrapped
+        // in `{}` while still folding into the brace annotation.
+        assert_eq!(
+            latex_to_typst(r"$\underbrace{x}_{a, b}$").trim(),
+            "$underbrace(x, {a, b})$"
+        );
+        assert_eq!(
+            latex_to_typst(r"$\underbrace{a, b}_{c}$").trim(),
+            "$underbrace({a, b}, c)$"
+        );
+        // Commas nested inside parens or a string literal are not top-level, so
+        // these still fold safely.
+        assert_eq!(
+            latex_to_typst(r"$\underbrace{f(x,y)}_{c}$").trim(),
+            "$underbrace(f(x,y), c)$"
+        );
+        assert_eq!(
+            latex_to_typst(r"$\underbrace{x}_{\text{a, b}}$").trim(),
+            r#"$underbrace(x, #text[a, b])$"#
+        );
+    }
+
+    #[test]
+    fn test_circled_operators_use_dot_o_spelling() {
+        // Issue #27: Typst deprecated the `.circle` circled-operator spelling in
+        // favour of `.o` (e.g. `times.o`). Emitting `times.circle` renders a
+        // deprecation warning and will eventually stop compiling.
+        assert_eq!(latex_to_typst(r"\otimes").trim(), "times.o");
+        assert_eq!(latex_to_typst(r"\oplus").trim(), "plus.o");
+        assert_eq!(latex_to_typst(r"\ominus").trim(), "minus.o");
+        assert_eq!(latex_to_typst(r"\odot").trim(), "dot.o");
+        assert_eq!(latex_to_typst(r"\oslash").trim(), "slash.o");
+        // n-ary (big) variants take the `.o.big` suffix.
+        assert_eq!(latex_to_typst(r"\bigotimes").trim(), "times.o.big");
+        assert_eq!(latex_to_typst(r"\bigoplus").trim(), "plus.o.big");
+        assert_eq!(latex_to_typst(r"\bigodot").trim(), "dot.o.big");
+    }
+
+    #[test]
+    fn test_dirac_notation_uses_chevron_delimiters() {
+        // Issue #29: bra-ket notation emitted `angle.l`/`angle.r`, which are not
+        // valid Typst delimiter symbols; the angle brackets ⟨ ⟩ are `chevron.l`
+        // / `chevron.r` (matching how `\langle`/`\rangle` already convert).
+        assert_eq!(latex_to_typst(r"\ket{x}").trim(), "lr(| x chevron.r)");
+        assert_eq!(latex_to_typst(r"\bra{x}").trim(), "lr(chevron.l x |)");
+        assert_eq!(
+            latex_to_typst(r"\braket{a}{b}").trim(),
+            "lr(chevron.l a | b chevron.r)"
+        );
+        assert_eq!(
+            latex_to_typst(r"\braket{x}").trim(),
+            "lr(chevron.l x | x chevron.r)"
+        );
+        // The shared delimiter fix also covers the other braket-family commands.
+        assert_eq!(
+            latex_to_typst(r"\mel{n}{A}{m}").trim(),
+            "lr(chevron.l n | A | m chevron.r)"
+        );
+        // `\dyad` builds the closing bra from a *second* `lr(` inside the same
+        // format string; exact-match here guards the space before the operand
+        // (a bare `contains` check would miss `chevron.lb`).
+        assert_eq!(
+            latex_to_typst(r"\dyad{a}{b}").trim(),
+            "lr(| a chevron.r) lr(chevron.l b |)"
+        );
+    }
+
+    #[test]
     fn test_spacing_commands_consume_dimension_arguments() {
         // hspace/vspace and their starred variants must be registered as 1-arg
         // commands so mitex consumes the dimension instead of leaking it
@@ -681,7 +805,13 @@ mod l2t_math {
     #[test]
     fn test_text_in_math() {
         let result = latex_to_typst(r"\text{hello}");
-        assert!(!result.contains("Error"));
+        assert_eq!(result.trim(), "#text[hello]");
+
+        let issue_label = latex_to_typst(r"\underbrace{U_p}_{\text{$p$th Layer}}");
+        assert_eq!(
+            issue_label.trim(),
+            r#"underbrace(U_(p), #text[$p$th Layer])"#
+        );
     }
 
     #[test]
@@ -3083,9 +3213,11 @@ mod citation_edge_cases {
 
     #[test]
     fn test_l2t_citation_edge_cases() {
+        // Typst's `#cite` takes one key, so multi-key groups split into separate
+        // calls; the shared postnote attaches to the final citation.
         let citep = latex_document_to_typst(r#"See \citep[see][ch. 2]{a,b}."#);
         assert!(
-            citep.contains(r#"See see #cite(<a>, <b>, supplement: [ch. 2])."#),
+            citep.contains(r#"See see #cite(<a>) #cite(<b>, supplement: [ch. 2])."#),
             "got: {}",
             citep
         );
@@ -3288,6 +3420,23 @@ mod t2l_escaped_punctuation {
     }
 
     #[test]
+    fn test_lr_linebreak_stays_inline_fragment() {
+        let result =
+            typst_to_latex_with_options(r"$lr(chevron.l a \ b chevron.r)$", &T2LOptions::default());
+
+        assert!(
+            result.contains(r"\left\langle") && result.contains(r"\right\rangle"),
+            "lr() should still render angle delimiters, got: {}",
+            result
+        );
+        assert!(
+            result.contains("a \\\n") && !result.contains("a \\\\\n"),
+            "linebreak inside lr() content should stay an inline fragment, got: {}",
+            result
+        );
+    }
+
+    #[test]
     fn test_matrix_escaped_punctuation_is_literal() {
         let result = typst_to_latex_with_options("$mat(1\\, 2; 3\\; 4)$", &T2LOptions::default());
 
@@ -3474,6 +3623,55 @@ mod t2l_escaped_punctuation {
         assert!(
             result.contains("A_{i \\\n") && result.contains("j}"),
             "non-limits multiline subscript should still emit a plain multiline brace group, got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_math_linebreak_in_align_becomes_double_backslash() {
+        // A Typst math line break (`\`) at the row level of an aligned equation
+        // must map to LaTeX's `\\` row separator; a lone `\` is not a valid row
+        // break. (`\ `, backslash-space, is a Typst line break.)
+        let result = typst_to_latex_with_options(r"$ a &= b \ &= c $", &T2LOptions::default());
+        assert!(
+            result.contains(r"\begin{align}"),
+            "aligned equation should use the align environment, got: {}",
+            result
+        );
+        assert!(
+            result.contains("b \\\\") && !result.contains("b \\\n"),
+            "row-level line break should emit `\\\\`, not a bare `\\`, got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_non_aligned_math_linebreak_stays_inline_spacing() {
+        // Without an alignment marker, the output stays in inline/display math
+        // rather than an align environment. In that context, emitting `\\`
+        // would create an invalid LaTeX row separator.
+        let result = typst_to_latex_with_options(r"$ a = b \ c = d $", &T2LOptions::default());
+        assert!(
+            result.contains("b \\\n") && !result.contains("b \\\\\n"),
+            "non-aligned math linebreak should stay a bare `\\`, got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_text_ampersand_does_not_trigger_align_linebreak() {
+        // Alignment detection must only consider top-level `&`; an ampersand
+        // inside text/braces is literal content and should not upgrade a math
+        // line break to a row separator.
+        let result = typst_to_latex_with_options(r#"$ text("&") \ a $"#, &T2LOptions::default());
+        assert!(
+            !result.contains(r"\begin{align}"),
+            "text ampersand should not create align environment, got: {}",
+            result
+        );
+        assert!(
+            result.contains(" \\\n") && !result.contains(" \\\\\n"),
+            "text ampersand linebreak should stay a bare `\\`, got: {}",
             result
         );
     }
@@ -4358,8 +4556,8 @@ mod physics_package {
     fn test_ket() {
         let result = latex_to_typst(r"\ket{\psi}");
         assert!(
-            result.contains("lr(|") && result.contains("angle.r"),
-            "\\ket should produce lr(| ψ angle.r), got: {}",
+            result.contains("lr(|") && result.contains("chevron.r"),
+            "\\ket should produce lr(| ψ chevron.r), got: {}",
             result
         );
     }
@@ -4368,8 +4566,8 @@ mod physics_package {
     fn test_bra() {
         let result = latex_to_typst(r"\bra{\phi}");
         assert!(
-            result.contains("angle.l") && result.contains("|)"),
-            "\\bra should produce lr(angle.l φ |), got: {}",
+            result.contains("chevron.l") && result.contains("|)"),
+            "\\bra should produce lr(chevron.l φ |), got: {}",
             result
         );
     }
@@ -4378,8 +4576,8 @@ mod physics_package {
     fn test_braket_two_args() {
         let result = latex_to_typst(r"\braket{a}{b}");
         assert!(
-            result.contains("angle.l") && result.contains("|") && result.contains("angle.r"),
-            "\\braket{{a}}{{b}} should produce lr(angle.l a | b angle.r), got: {}",
+            result.contains("chevron.l") && result.contains("|") && result.contains("chevron.r"),
+            "\\braket{{a}}{{b}} should produce lr(chevron.l a | b chevron.r), got: {}",
             result
         );
     }
@@ -4390,8 +4588,8 @@ mod physics_package {
         let output = result.trim();
         // Single-arg braket: ⟨a|a⟩
         assert!(
-            output.contains("angle.l") && output.contains("angle.r"),
-            "\\braket{{a}} should produce lr(angle.l a | a angle.r), got: {}",
+            output.contains("chevron.l") && output.contains("chevron.r"),
+            "\\braket{{a}} should produce lr(chevron.l a | a chevron.r), got: {}",
             result
         );
     }
@@ -4400,8 +4598,8 @@ mod physics_package {
     fn test_expval_implicit() {
         let result = latex_to_typst(r"\expval{A}");
         assert!(
-            result.contains("angle.l") && result.contains("angle.r"),
-            "\\expval{{A}} should produce lr(angle.l A angle.r), got: {}",
+            result.contains("chevron.l") && result.contains("chevron.r"),
+            "\\expval{{A}} should produce lr(chevron.l A chevron.r), got: {}",
             result
         );
     }
@@ -4411,8 +4609,8 @@ mod physics_package {
         let result = latex_to_typst(r"\expval{A}{\Psi}");
         eprintln!("expval result: {}", result);
         assert!(
-            result.contains("angle.l") && result.contains("|") && result.contains("angle.r"),
-            "\\expval{{A}}{{Ψ}} should produce lr(angle.l Ψ | A | Ψ angle.r), got: {}",
+            result.contains("chevron.l") && result.contains("|") && result.contains("chevron.r"),
+            "\\expval{{A}}{{Ψ}} should produce lr(chevron.l Ψ | A | Ψ chevron.r), got: {}",
             result
         );
     }
@@ -4421,8 +4619,8 @@ mod physics_package {
     fn test_mel() {
         let result = latex_to_typst(r"\mel{n}{A}{m}");
         assert!(
-            result.contains("angle.l") && result.contains("|") && result.contains("angle.r"),
-            "\\mel{{n}}{{A}}{{m}} should produce lr(angle.l n | A | m angle.r), got: {}",
+            result.contains("chevron.l") && result.contains("|") && result.contains("chevron.r"),
+            "\\mel{{n}}{{A}}{{m}} should produce lr(chevron.l n | A | m chevron.r), got: {}",
             result
         );
     }
@@ -4433,7 +4631,7 @@ mod physics_package {
         eprintln!("dyad result: {}", result);
         // |a⟩⟨b|
         assert!(
-            result.contains("angle.r") && result.contains("angle.l"),
+            result.contains("chevron.r") && result.contains("chevron.l"),
             "\\dyad{{a}}{{b}} should produce |a⟩⟨b|, got: {}",
             result
         );
@@ -4535,7 +4733,7 @@ Commutator: $\comm{x}{p} = i\hbar$
             result
         );
         assert!(
-            result.contains("angle.l") || result.contains("lr(|"),
+            result.contains("chevron.l") || result.contains("lr(|"),
             "Should contain bra-ket notation, got: {}",
             result
         );
@@ -4573,8 +4771,8 @@ Commutator: $\comm{x}{p} = i\hbar$
     fn test_vev() {
         let result = latex_to_typst(r"\vev{A}");
         assert!(
-            result.contains("angle.l") && result.contains("0") && result.contains("angle.r"),
-            "\\vev{{A}} should produce lr(angle.l 0 | A | 0 angle.r), got: {}",
+            result.contains("chevron.l") && result.contains("0") && result.contains("chevron.r"),
+            "\\vev{{A}} should produce lr(chevron.l 0 | A | 0 chevron.r), got: {}",
             result
         );
     }
@@ -4653,7 +4851,7 @@ Commutator: $\comm{x}{p} = i\hbar$
     fn test_braket_star() {
         let result = latex_to_typst(r"\braket*{a}{b}");
         assert!(
-            result.contains("angle.l") && result.contains("angle.r"),
+            result.contains("chevron.l") && result.contains("chevron.r"),
             "\\braket*{{a}}{{b}} should produce braket notation, got: {}",
             result
         );
@@ -4800,6 +4998,11 @@ mod t2l_symbol_mappings {
         assert_eq!(TYPST_TO_TEX.get("times.square"), Some(&"\\boxtimes"));
         assert_eq!(TYPST_TO_TEX.get("dot.circle"), Some(&"\\odot"));
         assert_eq!(TYPST_TO_TEX.get("minus.circle"), Some(&"\\ominus"));
+        assert_eq!(TYPST_TO_TEX.get("times.o"), Some(&"\\otimes"));
+        assert_eq!(TYPST_TO_TEX.get("plus.o"), Some(&"\\oplus"));
+        assert_eq!(TYPST_TO_TEX.get("minus.o"), Some(&"\\ominus"));
+        assert_eq!(TYPST_TO_TEX.get("dot.o"), Some(&"\\odot"));
+        assert_eq!(TYPST_TO_TEX.get("slash.o"), Some(&"\\oslash"));
     }
 
     #[test]

--- a/tools/gen_maps.py
+++ b/tools/gen_maps.py
@@ -41,8 +41,8 @@ SYMBOL_MAP = {
     # Binary operators
     "pm": "plus.minus", "mp": "minus.plus", "times": "times", "div": "div",
     "cdot": "dot.op", "ast": "ast", "star": "star", "circ": "circle.small",
-    "bullet": "bullet", "oplus": "plus.circle", "ominus": "minus.circle",
-    "otimes": "times.circle", "oslash": "divides.circle", "odot": "dot.circle",
+    "bullet": "bullet", "oplus": "plus.o", "ominus": "minus.o",
+    "otimes": "times.o", "oslash": "slash.o", "odot": "dot.o",
     "cap": "sect", "cup": "union", "sqcap": "sect.sq", "sqcup": "union.sq",
     "vee": "or", "wedge": "and", "setminus": "without",
     "wr": "wreath", "diamond": "diamond", "bigtriangleup": "triangle.t",
@@ -100,7 +100,7 @@ SYMBOL_MAP = {
     "dots": "dots", "dotsc": "dots.c", "dotsb": "dots.c", "dotsm": "dots.c",
     
     # Delimiters
-    "langle": "angle.l", "rangle": "angle.r",
+    "langle": "chevron.l", "rangle": "chevron.r",
     "lceil": "ceil.l", "rceil": "ceil.r",
     "lfloor": "floor.l", "rfloor": "floor.r",
     "lbrace": "brace.l", "rbrace": "brace.r",
@@ -112,8 +112,8 @@ SYMBOL_MAP = {
     "int": "integral", "iint": "integral.double", "iiint": "integral.triple",
     "oint": "integral.cont", "bigcap": "sect.big", "bigcup": "union.big",
     "bigsqcup": "union.sq.big", "bigvee": "or.big", "bigwedge": "and.big",
-    "bigoplus": "plus.circle.big", "bigotimes": "times.circle.big",
-    "bigodot": "dot.circle.big",
+    "bigoplus": "plus.o.big", "bigotimes": "times.o.big",
+    "bigodot": "dot.o.big",
     
     # Functions
     "sin": "sin", "cos": "cos", "tan": "tan", "cot": "cot",
@@ -236,6 +236,11 @@ TYPST_TO_TEX = {
     # Operators
     "plus.minus": "pm", "minus.plus": "mp", "times": "times", "div": "div",
     "dot.op": "cdot", "sect": "cap", "union": "cup",
+    "plus.o": "\\oplus", "plus.o.big": "\\bigoplus",
+    "minus.o": "\\ominus",
+    "times.o": "\\otimes", "times.o.big": "\\bigotimes",
+    "dot.o": "\\odot", "dot.o.big": "\\bigodot",
+    "slash.o": "\\oslash",
     "lt.eq": "leq", "gt.eq": "geq", "eq.not": "neq",
     "approx": "approx", "equiv": "equiv", "tilde.op": "sim",
     "subset": "subset", "supset": "supset", "subset.eq": "subseteq",

--- a/web/index.html
+++ b/web/index.html
@@ -19,7 +19,7 @@
             <div class="header-content">
                 <div class="logo">
                     <img src="logo.svg" alt="Tylax" class="logo-img">
-                    <span class="version-badge">v0.3.5</span>
+                    <span class="version-badge">v0.3.7</span>
                 </div>
                 <nav class="nav">
                     <a href="https://github.com/scipenai/tylax" target="_blank" class="nav-link" title="GitHub">


### PR DESCRIPTION
  Description

  Fixes a batch of math-conversion bugs in both directions and bumps the release to v0.3.7.

  LaTeX → Typst
  - Circled operators: \otimes, \oplus, \ominus, \odot, \oslash (and the \big* forms) emit Typst's current .o spelling
  (times.o, plus.o.big, …) instead of the deprecated .circle; reverse .o → LaTeX mappings are added so round-trips stay
  stable.
  - Dirac notation: bra-ket commands (\ket, \bra, \braket, \dyad, \expval, \mel, …) emit valid chevron.l / chevron.r
  delimiters instead of the non-existent angle.l / angle.r.
  - Brace annotations: \underbrace{x}_{y} / \overbrace{x}^{y} fold the label into Typst's second positional argument
  (underbrace(x, y)) instead of rendering it as a real subscript; top-level commas in either operand are protected.
  - Math slash: a literal / in math emits slash ($\mathbb{R} / \mathbb{Q}$ → RR slash QQ); \frac slash notation and
  text-mode / (URLs, and/or) are unaffected.
  - Citations: multi-key \cite{a,b} splits into separate #cite(<a>) #cite(<b>) calls instead of the invalid #cite(<a>,
  <b>).

  Typst → LaTeX
  - Aligned line breaks: a Typst math line break (\) in an aligned equation emits LaTeX's \\ row separator (previously a
  lone \, invalid in align), including from the WASM/web math entrypoint. Inline fragments (scripts, matrix cells,
  arguments) keep a bare \ where \\ would be invalid.
  - Alignment detection: only top-level, unescaped, non-brace & is treated as an alignment marker, so content like
  text("&") \ a no longer falsely produces an align environment.

  Split into two commits: the code fixes (fix:) and the release/version bump (chore(release):).

  Resolves #26, #27, #28, #29. Addresses #23 (underbrace + multi-key cite).

  Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [x] Documentation update (CHANGELOG, README install version, web version badge)
  - [ ] Refactoring

  Checklist

  - [x] Tests pass — cargo test --workspace (393 + 297 + 11) and wasm::tests
  - [x] No clippy warnings — cargo clippy -p tylax --all-features -- -D warnings
  - [x] Code formatted — cargo fmt --all -- --check
  - [x] Documentation updated — CHANGELOG [0.3.7], version bumped to 0.3.7